### PR TITLE
Revert "Made module work with globbed/multifile sources"

### DIFF
--- a/tasks/resxtojson.js
+++ b/tasks/resxtojson.js
@@ -62,52 +62,54 @@ module.exports = function(grunt) {
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
-      var sourceFileName,
+      var sourcePath, 
+      sourceFileName,
       fileContent,
       fileName, baseTranslation, outFilePath;
+
       // Create the destination directory, if it doesn't exist
       if (!File.isDir(f.dest)) {
         Info(sprintf('Destination directory created "%s"', f.dest));
         File.mkdir(f.dest);
       }
 
-      f.src.forEach(function(sourcePath){
-        if (!File.exists(sourcePath)) {
-          throw new Error(sprintf('Source file "%s" not found.', f.src));
+      sourcePath = f.src[0];
+
+      if (!File.exists(sourcePath)) {
+        throw new Error(sprintf('Source file "%s" not found.', f.src));
+      }
+
+      fileContent = File.read(sourcePath);
+      baseTranslation = resxtojson(fileContent, options.matchPattern);
+      sourceFileName = getFileNameFromPath(sourcePath);
+      outFilePath = path.join(f.dest, sourceFileName.replace('.resx', '.js'));
+      writeJSONOutput(outFilePath, JSON.stringify(baseTranslation));
+
+      var sourceFiles = File.expand(
+        [sourcePath.replace('.resx', '.*.resx')]);
+
+      sourceFiles.filter(function(filepath) {
+        // Warn on and remove invalid source files (if nonull was set).
+        if (!File.exists(filepath)) {
+          Warn(sprintf('Source file "%s" not found.', filepath));
+          return false;
+        } else {
+          return true;
+        }
+      }).forEach(function(filePath) {
+        var jsonFromResx;
+
+        fileContent = File.read(filePath);
+        try
+        {
+          jsonFromResx = extend({}, baseTranslation, resxtojson(fileContent, options.matchPattern));
+        } catch (key) {
+          throw new Error(sprintf('Error converting %s -> Value of %s cannot be parsed.', outFilePath, key));
         }
 
-        fileContent = File.read(sourcePath);
-        baseTranslation = resxtojson(fileContent, options.matchPattern);
-        sourceFileName = getFileNameFromPath(sourcePath);
-        outFilePath = path.join(f.dest, sourceFileName.replace('.resx', '.js'));
-        writeJSONOutput(outFilePath, JSON.stringify(baseTranslation));
-
-        var sourceFiles = File.expand(
-          [sourcePath.replace('.resx', '.*.resx')]);
-
-        sourceFiles.filter(function(filepath) {
-          // Warn on and remove invalid source files (if nonull was set).
-          if (!File.exists(filepath)) {
-            Warn(sprintf('Source file "%s" not found.', filepath));
-            return false;
-          } else {
-            return true;
-          }
-        }).forEach(function(filePath) {
-          var jsonFromResx;
-
-          fileContent = File.read(filePath);
-          try
-          {
-            jsonFromResx = extend({}, baseTranslation, resxtojson(fileContent, options.matchPattern));
-          } catch (key) {
-            throw new Error(sprintf('Error converting %s -> Value of %s cannot be parsed.', outFilePath, key));
-          }
-
-          fileName = getFileNameFromPath(filePath);
-          outFilePath = path.join(f.dest, fileName.replace('.resx', '.js'));
-          writeJSONOutput(outFilePath, JSON.stringify(jsonFromResx));
-        });
+        fileName = getFileNameFromPath(filePath);
+        outFilePath = path.join(f.dest, fileName.replace('.resx', '.js'));
+        writeJSONOutput(outFilePath, JSON.stringify(jsonFromResx));
       });
     });
   });


### PR DESCRIPTION
The base translation is no longer correctly applied. Using the globbing pattern in this way simply translates all resx files without fallback.